### PR TITLE
Switch default text color to match primary color

### DIFF
--- a/Starter themes/advanced-59/theme.json
+++ b/Starter themes/advanced-59/theme.json
@@ -386,7 +386,7 @@
 		},
 		"color": {
 			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
+			"text": "var(--wp--preset--color--primary)"
 		},
 		"typography": {
 			"fontSize": "var(--wp--preset--font-size--medium)",


### PR DESCRIPTION
Switch default text color to match primary color instead of the "foreground" color, which according to these styles is a super light-weight and difficult to see gray color.