### PR TITLE
Adding Google Font to drop cap selection

### DIFF
--- a/Starter themes/advanced-59/theme.json
+++ b/Starter themes/advanced-59/theme.json
@@ -101,6 +101,11 @@
 			"dropCap": false,
 			"fontFamilies": [
 				{
+					"name": "Lora",
+					"slug": "lora",
+					"fontFamily": "Lora, serif"
+				},
+				{
 					"name": "System",
 					"slug": "system",
 					"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif"


### PR DESCRIPTION
Adds in the example Google font family ('Lora') into the default options for drop caps